### PR TITLE
add loading spinner

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,7 +11,8 @@
         "haiku-readme": "file:..",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "react-share": "^5.2.2"
+        "react-share": "^5.2.2",
+        "react-spinners": "^0.17.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.26.0",
@@ -4575,6 +4576,16 @@
       },
       "peerDependencies": {
         "react": "^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/react-spinners": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-spinners/-/react-spinners-0.17.0.tgz",
+      "integrity": "sha512-L/8HTylaBmIWwQzIjMq+0vyaRXuoAevzWoD35wKpNTxxtYXWZp+xtgkfD7Y4WItuX0YvdxMPU79+7VhhmbmuTQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,8 @@
     "haiku-readme": "file:..",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-share": "^5.2.2"
+    "react-share": "^5.2.2",
+    "react-spinners": "^0.17.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.26.0",

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -191,3 +191,18 @@ a:hover {
   min-height: 200px;
 }
 
+.clip-loader {
+  width: 50px;
+  height: 50px;
+  border: 5px solid #36d7b7;
+  border-bottom-color: transparent;
+  border-radius: 50%;
+  animation: spin 0.75s linear infinite;
+  display: inline-block;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -191,18 +191,10 @@ a:hover {
   min-height: 200px;
 }
 
-.clip-loader {
-  width: 50px;
-  height: 50px;
-  border: 5px solid #36d7b7;
-  border-bottom-color: transparent;
-  border-radius: 50%;
-  animation: spin 0.75s linear infinite;
-  display: inline-block;
-}
-
-@keyframes spin {
-  to {
-    transform: rotate(360deg);
-  }
+/* Using max-height instead of display: none to ensure the image loads 
+and triggers onLoad/onError correctly, while avoiding a visible flicker 
+between spinner and image on slow networks. */
+.hide-haiku {
+  max-height: 1px;
+  visibility: hidden;
 }

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -184,3 +184,10 @@ a:hover {
   justify-content: center; /* 👈 Center horizontally */
 }
 
+.spinner-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 200px;
+}
+

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -10,7 +10,6 @@ import {
 } from 'react-share';
 import { ClipLoader } from 'react-spinners';
 
-
 function App() {
   const [theme, setTheme] = useState('catppuccin_mocha');
   const [type, setType] = useState('vertical');
@@ -139,7 +138,7 @@ function App() {
         )}
 
         <img
-          className={isLoading ? "hide-haiku" : ""}
+          className={isLoading ? 'hide-haiku' : ''}
           src={svgUrl}
           alt="Haiku SVG"
           onLoad={() => setIsLoading(false)}
@@ -174,7 +173,6 @@ function App() {
         ) : (
           <p>Please generate a haiku to enable sharing.</p>
         )}
-
       </div>
 
       <footer>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -139,6 +139,7 @@ function App() {
         )}
 
         <img
+          className={isLoading ? "hide-haiku" : ""}
           src={svgUrl}
           alt="Haiku SVG"
           onLoad={() => setIsLoading(false)}
@@ -146,10 +147,6 @@ function App() {
             setIsLoading(false);
             alert('Failed to load SVG');
           }}
-          // Using minimal height instead of display: none to ensure the image loads 
-          // and triggers onLoad/onError correctly, while avoiding a visible flicker 
-          // between spinner and image on slow networks.
-          style={{ height: isLoading ? '1px' : ''}}
         />
       </div>
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import './App.css';
 import {
   TwitterShareButton,
@@ -8,7 +8,6 @@ import {
   FacebookIcon,
   LinkedinIcon,
 } from 'react-share';
-import { useEffect } from 'react';
 import { ClipLoader } from 'react-spinners';
 
 
@@ -17,6 +16,10 @@ function App() {
   const [type, setType] = useState('vertical');
   const [border, setBorder] = useState(true);
   const [isLoading, setIsLoading] = useState(true);
+
+  // Spinner styles
+  const SPINNER_COLOR = '#36d7b7';
+  const SPINNER_SIZE = 50;
 
   const themes = [
     'catppuccin_mocha',
@@ -131,7 +134,7 @@ function App() {
 
         {isLoading && (
           <div className="spinner-container">
-            <ClipLoader color="#36d7b7" size={50} />
+            <ClipLoader color={SPINNER_COLOR} size={SPINNER_SIZE} />
           </div>
         )}
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -8,11 +8,15 @@ import {
   FacebookIcon,
   LinkedinIcon,
 } from 'react-share';
+import { useEffect } from 'react';
+import { ClipLoader } from 'react-spinners';
+
 
 function App() {
   const [theme, setTheme] = useState('catppuccin_mocha');
   const [type, setType] = useState('vertical');
   const [border, setBorder] = useState(true);
+  const [isLoading, setIsLoading] = useState(true);
 
   const themes = [
     'catppuccin_mocha',
@@ -76,6 +80,10 @@ function App() {
     setBorder(Math.round(Math.random()) === 1 ? true : false);
   };
 
+  useEffect(() => {
+    setIsLoading(true);
+  }, [theme, type, border]);
+
   return (
     <div className="App">
       <header>
@@ -120,10 +128,25 @@ function App() {
 
       <div className="preview">
         <h2>Preview</h2>
+
+        {isLoading && (
+          <div className="spinner-container">
+            <ClipLoader color="#36d7b7" size={50} />
+          </div>
+        )}
+
         <img
           src={svgUrl}
           alt="Haiku SVG"
-          onError={() => alert('Failed to load SVG')}
+          onLoad={() => setIsLoading(false)}
+          onError={() => {
+            setIsLoading(false);
+            alert('Failed to load SVG');
+          }}
+          // Using minimal height instead of display: none to ensure the image loads 
+          // and triggers onLoad/onError correctly, while avoiding a visible flicker 
+          // between spinner and image on slow networks.
+          style={{ height: isLoading ? '1px' : ''}}
         />
       </div>
 


### PR DESCRIPTION
# HaikuReadme Pull Request

## 🧩 Related Issue

**Issue Number:** #20

---

## ✨ What Changes Did You Make?

I added a loading spinner using the react-spinners ClipLoader component to display while the haiku image is being fetched. The spinner shows immediately when the user changes the theme, type, or border, and it disappears once the image finishes loading. To prevent a flicker or empty space during loading, I kept the image rendered with a minimal height until it's fully loaded.

---

## 🛠️ Type of Changes

*Check all that apply:*

- [x]  **Frontend**: Changes to `frontend/` (e.g., `App.jsx`, `App.css`, UI tweaks)
- [ ]  **Backend**: Changes to `backend/` (e.g., `index.js`, `svg.js`, `words.json`)
- [x]  **Documentation**: Changes to `README.md`, `CONTRIBUTING.md`, etc.
- [ ]  **Configuration**: Changes to `vercel.json`, `.gitignore`, etc.
- [ ]  **Bug Fix**: Fixed an issue (describe briefly)
- [x]  **New Feature**: Added something new (describe briefly)
loading spinner when generating a new Haiku
- [ ]  **Other**: (specify, e.g., CI/CD, GitHub Actions)

---

## ✅ Contributor Checklist

Please check these to confirm your PR is ready:

- [x]  I’ve followed the steps in `CONTRIBUTING.md`.
- [x]  I’ve tested my changes locally.
- [x]  My code follows the project’s style (e.g., no trailing spaces, clear comments).
- [x]  I’ve linked this PR to the correct issue (if applicable).
- [x]  I’ve updated `README.md` or other docs if needed.