### PR TITLE
Expand Tech-Related Words in backend/lib/words.json (#15)

### DIFF
--- a/backend/lib/words.json
+++ b/backend/lib/words.json
@@ -11,7 +11,20 @@
     { "word": "stream", "syllables": 1 },
     { "word": "dawn", "syllables": 1 },
     { "word": "coffee", "syllables": 2 },
-    { "word": "commit", "syllables": 2 }
+    { "word": "commit", "syllables": 2 },
+    { "word": "byte", "syllables": 1 },
+    { "word": "packet", "syllables": 2 },
+    { "word": "kernel", "syllables": 2 },
+    { "word": "terminal", "syllables": 3 },
+    { "word": "protocol", "syllables": 3 },
+    { "word": "compiler", "syllables": 3 },
+    { "word": "firewall", "syllables": 2 },
+    { "word": "script", "syllables": 1 },
+    { "word": "database", "syllables": 3 },
+    { "word": "silicon", "syllables": 3 },
+    { "word": "processor", "syllables": 3 },
+    { "word": "cache", "syllables": 1 },
+    { "word": "framework", "syllables": 2 }
   ],
   "verbs": [
     { "word": "flows", "syllables": 1 },
@@ -22,7 +35,14 @@
     { "word": "runs", "syllables": 1 },
     { "word": "build", "syllables": 1 },
     { "word": "merge", "syllables": 1 },
-    { "word": "brings", "syllables": 1 }
+    { "word": "brings", "syllables": 1 },
+    { "word": "deploy", "syllables": 2 },
+    { "word": "transmit", "syllables": 2 },
+    { "word": "reboot", "syllables": 2 },
+    { "word": "execute", "syllables": 3 },
+    { "word": "encrypt", "syllables": 2 },
+    { "word": "decode", "syllables": 2 },
+    { "word": "render", "syllables": 2 }
   ],
   "adjectives": [
     { "word": "swift", "syllables": 1 },
@@ -30,13 +50,23 @@
     { "word": "elegant", "syllables": 3 },
     { "word": "bright", "syllables": 1 },
     { "word": "bold", "syllables": 1 },
-    { "word": "clean", "syllables": 1 }
+    { "word": "clean", "syllables": 1 },
+    { "word": "virtual", "syllables": 3 },
+    { "word": "encrypted", "syllables": 3 },
+    { "word": "binary", "syllables": 3 },
+    { "word": "digital", "syllables": 3 },
+    { "word": "scalable", "syllables": 3 },
+    { "word": "dynamic", "syllables": 3 }
   ],
   "adverbs": [
     { "word": "softly", "syllables": 2 },
     { "word": "quickly", "syllables": 2 },
     { "word": "boldly", "syllables": 2 },
     { "word": "calmly", "syllables": 2 },
-    { "word": "carefully", "syllables": 3 }
+    { "word": "carefully", "syllables": 3 },
+    { "word": "remotely", "syllables": 3 },
+    { "word": "smoothly", "syllables": 2 },
+    { "word": "securely", "syllables": 3 },
+    { "word": "efficiently", "syllables": 4 }
   ]
 }


### PR DESCRIPTION
# HaikuReadme Pull Request

---

## 🧩 Related Issue

**Issue Number:** #15  

This PR expands the tech-related word list for haikus, enriching variety and relevance.

---

## ✨ What Changes Did You Make?

- Added 20+ new tech-related words to `backend/lib/words.json` (e.g., `byte`, `packet`, `kernel`, `terminal`, `compiler`, `script`, `database`, `deploy`, `reboot`, `virtual`, `binary`, `digital`, `securely`, etc.).  
- Tested (locally) to ensure that the new words appear in haikus generated by the local API at:  
  `http://localhost:3000/api?theme=catppuccin_mocha&type=vertical&border=true`.  
- Ensured words fit typical haiku syllable counts (1–4 syllables).  
- Maintained JSON formatting and avoided duplicates.

---

## 🛠️ Type of Changes

- [ ] **Frontend**: Changes to `frontend/`  
- [x] **Backend**: Changes to `backend/` (`words.json`)  
- [ ] **Documentation**: Changes to `README.md`, `CONTRIBUTING.md`, etc.  
- [ ] **Configuration**: Changes to `vercel.json`, `.gitignore`, etc.  
- [ ] **Bug Fix**: Fixed an issue  
- [ ] **New Feature**: Added something new  
- [ ] **Other**:  

---

## 📸 Screenshots (Optional)

Here is an example of a generated haiku showing one of the new words:  
<img width="805" height="343" alt="New_word_test" src="https://github.com/user-attachments/assets/6421302f-6d0d-467a-8a99-e71157383fec" />

 Screenshot from my local API showing a haiku containing a newly added words `packet` and `script`.

---

## ✅ Contributor Checklist

- [x] I’ve followed the steps in `CONTRIBUTING.md`.  
- [x] I’ve tested my changes locally.  
- [x] My code follows the project’s style (e.g., no trailing spaces, clear comments).  
- [x] I’ve linked this PR to the correct issue (#15).  
- [ ] I’ve updated `README.md` or other docs if needed.  

---
